### PR TITLE
Setup custom router after creating the Application

### DIFF
--- a/aioworkers_aiohttp/abc.py
+++ b/aioworkers_aiohttp/abc.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 try:
     from typing import Protocol
-except ImportError:
+except ImportError:  # no cov
     from typing_extensions import Protocol  # type: ignore
 
 

--- a/aioworkers_aiohttp/abc.py
+++ b/aioworkers_aiohttp/abc.py
@@ -1,5 +1,11 @@
 from abc import ABC, abstractmethod
-from typing import Protocol
+
+
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
+
 
 from aiohttp.web import Application
 

--- a/aioworkers_aiohttp/abc.py
+++ b/aioworkers_aiohttp/abc.py
@@ -1,4 +1,21 @@
-from abc import ABC
+from abc import ABC, abstractmethod
+from typing import Protocol
+
+from aiohttp.web import Application
+
+
+class PRouter(Protocol):
+    @abstractmethod
+    def setup(self, app: Application):
+        pass
+
+    @abstractmethod
+    def set_cors(self, app: Application, **kwargs):
+        pass
+
+    @abstractmethod
+    def add_resource(self, url: str, **kwargs):
+        pass
 
 
 class AbstractSwaggerRouter(ABC):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,7 @@ exclude_lines = [
     "no cov",
     "if __name__ == .__main__.:",
     "if TYPE_CHECKING:",
+    "@abstractmethod",
 ]
 
 [tool.black]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,5 +1,7 @@
 import pytest
 
+from aioworkers_aiohttp.abc import AbstractSwaggerRouter
+
 
 async def startup(app):
     app['1234'] = None
@@ -35,3 +37,4 @@ async def test_init(context):
     assert 'app' in context
     assert 'timestamp' in context.app.router
     assert 'block:date' in context.app.router
+    assert isinstance(context.app.router, AbstractSwaggerRouter)

--- a/tests/test_app_router.py
+++ b/tests/test_app_router.py
@@ -1,0 +1,24 @@
+import pytest
+
+from aioworkers_aiohttp.abc import AbstractSwaggerRouter
+
+
+@pytest.fixture
+def config_yaml():
+    return """
+    app:
+      router:
+        setup: true
+      resources:
+        /timestamp:
+          name: timestamp
+          priority: 1
+          get:
+            handler: uuid.uuid4
+    """
+
+
+async def test_init(context):
+    assert 'app' in context
+    assert 'timestamp' in context.app.router
+    assert not isinstance(context.app.router, AbstractSwaggerRouter)


### PR DESCRIPTION
Use method of router to setup:

    router.setup(app)

For aiohttp<4 use explicit param setup:

    router:
       setup: true

Motivation:
* aiohttp>=4 not supported custom router as parameter of Application
* Use inside middleware (https://github.com/aamalev/aiohttp_apiset/pull/173)